### PR TITLE
Add return to check_model of warnings.sso

### DIFF
--- a/R/check_model.R
+++ b/R/check_model.R
@@ -6,6 +6,7 @@
 #'   binary to run. See the ss3sim vignette for instructions.
 #'
 #' @export
+#' @return A data frame of warnings produced from SS3.
 
 check_model <- function(model, opts = "-nohess",
   ss_mode = c("safe", "optimized")) {
@@ -28,5 +29,9 @@ check_model <- function(model, opts = "-nohess",
   file.copy(file.path(model, f), td, overwrite = TRUE)
   setwd(td)
   system(paste(ss_bin, opts))
+  warns <- readLines("warning.sso")[-c(1:2)]
+  warns <- warns[warns != ""]
+  warns <- data.frame("model" = model, "warnings" = warns)
   setwd(wd)
+  return(warns)
 }

--- a/man/check_model.Rd
+++ b/man/check_model.Rd
@@ -15,6 +15,9 @@ check_model(model, opts = "-nohess", ss_mode = c("safe", "optimized"))
   for which SS3 binary to run. See the ss3sim vignette for
   instructions.}
 }
+\value{
+A data frame of warnings produced from SS3.
+}
 \description{
 Check SS3 models
 }


### PR DESCRIPTION
Added a return from check_model based on data from warning.sso.
Now you output to see the warnings from each model you checked.
@seananderson I don't think I broke anything but can you make sure that
this is not stupid or illegal according to testthat.
