### PR TITLE
turned on CumReport.sso for all EMs, including those not using to be con...

### DIFF
--- a/R/make_starter.R
+++ b/R/make_starter.R
@@ -36,7 +36,7 @@ make_starter <- function(outfile = "starter.ss", dir = NULL, type = c("om", "em"
   data$detailed_age_structure <- 1
   data$checkup                <- 0
   data$parmtrace              <- 0
-  data$cumreport              <- 0
+  data$cumreport              <- ifelse(type == "om", 0, 1)
   data$prior_like             <- 0
   data$soft_bounds            <- 1
   data$N_bootstraps           <- 2

--- a/inst/models/cod/em/starter.ss
+++ b/inst/models/cod/em/starter.ss
@@ -10,7 +10,7 @@ ss3.ctl
 1 # detailed age-structured reports in REPORT.SSO (0,1) 
 0 # write detailed info from first call to echoinput.sso (0,1) 
 0 # write parm values to ParmTrace.sso (0=no,1=good,active; 2=good,all; 3=every_iter,all_parms; 4=every,active)
-0 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
+1 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
 0 # Include prior_like for non-estimated parameters (0,1) 
 1 # Use Soft Boundaries to aid convergence (0,1) (recommended)
 2 # Number of datafiles to produce: 1st is input, 2nd is estimates, 3rd and higher are bootstrap

--- a/inst/models/flatfish/em/starter.ss
+++ b/inst/models/flatfish/em/starter.ss
@@ -10,7 +10,7 @@ ss3.ctl
 1 # detailed age-structured reports in REPORT.SSO (0,1) 
 0 # write detailed info from first call to echoinput.sso (0,1) 
 0 # write parm values to ParmTrace.sso (0=no,1=good,active; 2=good,all; 3=every_iter,all_parms; 4=every,active)
-0 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
+1 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
 0 # Include prior_like for non-estimated parameters (0,1) 
 1 # Use Soft Boundaries to aid convergence (0,1) (recommended)
 2 # Number of datafiles to produce: 1st is input, 2nd is estimates, 3rd and higher are bootstrap

--- a/inst/models/hake-age/em/starter.ss
+++ b/inst/models/hake-age/em/starter.ss
@@ -10,7 +10,7 @@ ss3.ctl
 1 # detailed age-structured reports in REPORT.SSO (0,1) 
 0 # write detailed info from first call to echoinput.sso (0,1) 
 0 # write parm values to ParmTrace.sso (0=no,1=good,active; 2=good,all; 3=every_iter,all_parms; 4=every,active)
-0 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
+1 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
 0 # Include prior_like for non-estimated parameters (0,1) 
 1 # Use Soft Boundaries to aid convergence (0,1) (recommended)
 2 # Number of datafiles to produce: 1st is input, 2nd is estimates, 3rd and higher are bootstrap

--- a/inst/models/hake/em/starter.ss
+++ b/inst/models/hake/em/starter.ss
@@ -10,7 +10,7 @@ ss3.ctl
 1 # detailed age-structured reports in REPORT.SSO (0,1) 
 0 # write detailed info from first call to echoinput.sso (0,1) 
 0 # write parm values to ParmTrace.sso (0=no,1=good,active; 2=good,all; 3=every_iter,all_parms; 4=every,active)
-0 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
+1 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
 0 # Include prior_like for non-estimated parameters (0,1) 
 1 # Use Soft Boundaries to aid convergence (0,1) (recommended)
 2 # Number of datafiles to produce: 1st is input, 2nd is estimates, 3rd and higher are bootstrap

--- a/inst/models/mackerel-age/em/starter.ss
+++ b/inst/models/mackerel-age/em/starter.ss
@@ -10,7 +10,7 @@ ss3.ctl
 1 # detailed age-structured reports in REPORT.SSO (0,1) 
 0 # write detailed info from first call to echoinput.sso (0,1) 
 0 # write parm values to ParmTrace.sso (0=no,1=good,active; 2=good,all; 3=every_iter,all_parms; 4=every,active)
-0 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
+1 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
 0 # Include prior_like for non-estimated parameters (0,1) 
 1 # Use Soft Boundaries to aid convergence (0,1) (recommended)
 2 # Number of datafiles to produce: 1st is input, 2nd is estimates, 3rd and higher are bootstrap

--- a/inst/models/mackerel/em/starter.ss
+++ b/inst/models/mackerel/em/starter.ss
@@ -10,7 +10,7 @@ ss3.ctl
 1 # detailed age-structured reports in REPORT.SSO (0,1) 
 0 # write detailed info from first call to echoinput.sso (0,1) 
 0 # write parm values to ParmTrace.sso (0=no,1=good,active; 2=good,all; 3=every_iter,all_parms; 4=every,active)
-0 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
+1 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
 0 # Include prior_like for non-estimated parameters (0,1) 
 1 # Use Soft Boundaries to aid convergence (0,1) (recommended)
 2 # Number of datafiles to produce: 1st is input, 2nd is estimates, 3rd and higher are bootstrap

--- a/inst/models/yellow-age/em/starter.ss
+++ b/inst/models/yellow-age/em/starter.ss
@@ -10,7 +10,7 @@ ss3.ctl
 1 # detailed age-structured reports in REPORT.SSO (0,1) 
 0 # write detailed info from first call to echoinput.sso (0,1) 
 0 # write parm values to ParmTrace.sso (0=no,1=good,active; 2=good,all; 3=every_iter,all_parms; 4=every,active)
-0 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
+1 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
 0 # Include prior_like for non-estimated parameters (0,1) 
 1 # Use Soft Boundaries to aid convergence (0,1) (recommended)
 2 # Number of datafiles to produce: 1st is input, 2nd is estimates, 3rd and higher are bootstrap

--- a/inst/models/yellow/em/starter.ss
+++ b/inst/models/yellow/em/starter.ss
@@ -10,7 +10,7 @@ ss3.ctl
 1 # detailed age-structured reports in REPORT.SSO (0,1) 
 0 # write detailed info from first call to echoinput.sso (0,1) 
 0 # write parm values to ParmTrace.sso (0=no,1=good,active; 2=good,all; 3=every_iter,all_parms; 4=every,active)
-0 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
+1 # write to cumreport.sso (0=no,1=like&timeseries; 2=add survey fits)
 0 # Include prior_like for non-estimated parameters (0,1) 
 1 # Use Soft Boundaries to aid convergence (0,1) (recommended)
 2 # Number of datafiles to produce: 1st is input, 2nd is estimates, 3rd and higher are bootstrap


### PR DESCRIPTION
Hi all, I wanted to return the number of iterations it took the EM to converge. This is ONLY found in the CumReport.sso file which we currently have turned off in the starter files. I manually turned this on for the EM (obviously the OM will only be 1) and suggest that all groups should use these updated models.

I also tweaked the `ss3sim` results code to look for this file and if it's there to return `Niterations` in the scalar file. If the file is not there it returns NA. 

Does anyone have any objections to this?

@kellijohnson I vaguely remember you writing the starter files with a function. If we go this route should modify that function or just leave them changed manually?
